### PR TITLE
Add persistent teacher session and reset option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,12 +26,17 @@ function App() {
   return (
     <>
       {mode === 'landing' && <Landing onModeSelect={handleModeSelect} />}
-      {mode === 'teacher' && <TeacherView onModeSelect={handleModeSelect} />}
+      {mode === 'teacher' && (
+        <TeacherView
+          onModeSelect={handleModeSelect}
+          sessionCode={sessionCode}
+        />
+      )}
       {mode === 'student' && <StudentView sessionCode={sessionCode} />}
       {mode === 'results' && (
         <ResultsView 
           sessionCode={sessionCode} 
-          onBack={() => handleModeSelect('teacher')} 
+          onBack={() => handleModeSelect('teacher', sessionCode)}
         />
       )}
     </>

--- a/src/components/TeacherView.js
+++ b/src/components/TeacherView.js
@@ -3,17 +3,30 @@ import { Users, Eye } from 'lucide-react';
 import QRGenerator from './QRGenerator';
 import { useSession } from '../hooks/useSession';
 
-const TeacherView = ({ onModeSelect }) => {
-  const [sessionCode, setSessionCode] = useState('');
-  const { responses, createSession } = useSession(sessionCode);
+const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode }) => {
+  const [sessionCode, setSessionCode] = useState(initialSessionCode || '');
+  const { responses, createSession, clearSession } = useSession(sessionCode);
+
+  const handleReset = async () => {
+    await clearSession();
+    const newCode = await createSession();
+    setSessionCode(newCode);
+    onModeSelect('teacher', newCode);
+  };
 
   useEffect(() => {
     const initSession = async () => {
-      const code = await createSession();
-      setSessionCode(code);
+      if (!initialSessionCode) {
+        const code = await createSession();
+        setSessionCode(code);
+        // notify parent so the session code persists across views
+        onModeSelect('teacher', code);
+      } else {
+        setSessionCode(initialSessionCode);
+      }
     };
     initSession();
-  }, []);
+  }, [initialSessionCode]);
 
   return (
     <div className="min-h-screen bg-black text-white p-4">
@@ -48,7 +61,14 @@ const TeacherView = ({ onModeSelect }) => {
             <Eye className="w-5 h-5" />
             Ver Resultados en Tiempo Real
           </button>
-          
+
+          <button
+            onClick={handleReset}
+            className="px-8 py-3 bg-red-600 rounded-full font-medium hover:bg-red-500 transition-all"
+          >
+            Limpiar Resultados y Reiniciar
+          </button>
+
           <button
             onClick={() => onModeSelect('landing')}
             className="px-8 py-3 bg-gray-800 rounded-full font-medium hover:bg-gray-700 transition-all"

--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ref, set, onValue, push } from 'firebase/database';
+import { ref, set, onValue, push, remove } from 'firebase/database';
 import { database } from '../config/firebase';
 
 export const useSession = (sessionCode) => {
@@ -44,7 +44,7 @@ export const useSession = (sessionCode) => {
 
   const submitResponse = async (studentName, answers) => {
     if (!database) return;
-    
+
     const responsesRef = ref(database, `sessions/${sessionCode}/responses`);
     await push(responsesRef, {
       studentName,
@@ -53,5 +53,11 @@ export const useSession = (sessionCode) => {
     });
   };
 
-  return { session, responses, loading, createSession, submitResponse };
+  const clearSession = async () => {
+    if (!database || !sessionCode) return;
+    const sessionRef = ref(database, `sessions/${sessionCode}`);
+    await remove(sessionRef);
+  };
+
+  return { session, responses, loading, createSession, submitResponse, clearSession };
 };


### PR DESCRIPTION
## Summary
- keep teacher session when returning from results
- allow restarting a new session after clearing results
- expose `clearSession` in hook

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840b32930388330b8e960b33cc40c8d