### PR TITLE
Add basic admin panel for quizzes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,20 @@ npm install
 npm start
 ```
 
-La app estará disponible en http://localhost:3000
+ La app estará disponible en http://localhost:3000
 
 ### Despliegue
 
 - Puedes desplegar en Netlify, Vercel o cualquier hosting estático.
 - Recuerda configurar las variables de entorno en el panel del hosting.
+
+## 🛠 Panel de Administración
+
+1. Accede a `/admin` e inicia sesión con Google.
+2. Podrás ver la lista de quizzes guardados en la base de datos.
+3. Usa **Nuevo Quiz** para crear uno o **Editar** para modificar un existente.
+4. Completa el título, un slug opcional y las preguntas. Marca las respuestas correctas con `*` al inicio de la línea.
+5. Al guardar se mostrará la URL resultante (`/quiz/<quizId>`). Comparte esa dirección con tus estudiantes.
 
 ---
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
+import { Routes, Route } from 'react-router-dom';
 import Landing from './components/Landing';
 import TeacherView from './components/TeacherView';
 import StudentView from './components/StudentView';
 import ResultsView from './components/ResultsView';
+import AdminPanel from './components/AdminPanel';
+import QuizView from './components/QuizView';
 
-function App() {
+function Home() {
   const [mode, setMode] = useState('landing');
   const [sessionCode, setSessionCode] = useState('');
 
@@ -34,12 +37,22 @@ function App() {
       )}
       {mode === 'student' && <StudentView sessionCode={sessionCode} />}
       {mode === 'results' && (
-        <ResultsView 
-          sessionCode={sessionCode} 
+        <ResultsView
+          sessionCode={sessionCode}
           onBack={() => handleModeSelect('teacher', sessionCode)}
         />
       )}
     </>
+  );
+}
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/admin" element={<AdminPanel />} />
+      <Route path="/quiz/:id" element={<QuizView />} />
+      <Route path="*" element={<Home />} />
+    </Routes>
   );
 }
 

--- a/src/components/AdminPanel.js
+++ b/src/components/AdminPanel.js
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from 'react';
+import { ref, onValue, set } from 'firebase/database';
+import { database } from '../config/firebase';
+import { useAuth } from '../hooks/useAuth';
+import { Link } from 'react-router-dom';
+
+const emptyQuestion = {
+  id: '',
+  type: 'trueFalse',
+  title: '',
+  subtitle: '',
+  options: []
+};
+
+const AdminPanel = () => {
+  const { user, signIn, signOut } = useAuth();
+  const [quizzes, setQuizzes] = useState({});
+  const [editingId, setEditingId] = useState(null);
+  const [quizData, setQuizData] = useState({ title: '', questions: [] });
+
+  useEffect(() => {
+    if (!database) return;
+    const qRef = ref(database, 'quizzes');
+    const unsub = onValue(qRef, (snap) => {
+      setQuizzes(snap.val() || {});
+    });
+    return () => unsub();
+  }, []);
+
+  const startNew = () => {
+    setEditingId('');
+    setQuizData({ title: '', questions: [ { ...emptyQuestion } ] });
+  };
+
+  const editQuiz = (id) => {
+    setEditingId(id);
+    const data = quizzes[id];
+    if (data) setQuizData(data);
+  };
+
+  const addQuestion = () => {
+    setQuizData({ ...quizData, questions: [...quizData.questions, { ...emptyQuestion }] });
+  };
+
+  const saveQuiz = async () => {
+    if (!database) return;
+    const id = editingId || quizData.slug || quizData.title.toLowerCase().replace(/\s+/g,'-');
+    const quizRef = ref(database, `quizzes/${id}`);
+    await set(quizRef, quizData);
+    setEditingId(null);
+    alert(`Quiz guardado en /quiz/${id}`);
+  };
+
+  if (!user) {
+    return (
+      <div className="p-4 text-center">
+        <button onClick={signIn} className="bg-blue-500 text-white px-4 py-2 rounded">Iniciar sesión con Google</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 max-w-4xl mx-auto space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Panel de Administración</h1>
+        <button onClick={signOut} className="text-sm text-blue-500">Cerrar sesión</button>
+      </div>
+
+      {!editingId && editingId !== '' && (
+        <div>
+          <button onClick={startNew} className="bg-green-500 text-white px-4 py-2 rounded">Nuevo Quiz</button>
+          <ul className="mt-4 space-y-2">
+            {Object.entries(quizzes).map(([id, q]) => (
+              <li key={id} className="flex justify-between bg-gray-100 p-2 rounded">
+                <span>{q.title}</span>
+                <div>
+                  <button onClick={() => editQuiz(id)} className="text-blue-500 mr-2">Editar</button>
+                  <Link to={`/quiz/${id}`} className="text-green-500" target="_blank">Ver</Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {(editingId || editingId === '') && (
+        <div className="space-y-4">
+          <input
+            type="text"
+            placeholder="Título"
+            value={quizData.title}
+            onChange={(e) => setQuizData({ ...quizData, title: e.target.value })}
+            className="w-full border p-2"
+          />
+          <input
+            type="text"
+            placeholder="Slug opcional"
+            value={quizData.slug || ''}
+            onChange={(e) => setQuizData({ ...quizData, slug: e.target.value })}
+            className="w-full border p-2"
+          />
+
+          {quizData.questions.map((q, idx) => (
+            <div key={idx} className="border p-2 rounded space-y-2">
+              <input
+                type="text"
+                placeholder="ID"
+                value={q.id}
+                onChange={(e) => {
+                  const qs = [...quizData.questions];
+                  qs[idx].id = e.target.value;
+                  setQuizData({ ...quizData, questions: qs });
+                }}
+                className="w-full border p-1"
+              />
+              <select
+                value={q.type}
+                onChange={(e) => {
+                  const qs = [...quizData.questions];
+                  qs[idx].type = e.target.value;
+                  setQuizData({ ...quizData, questions: qs });
+                }}
+                className="w-full border p-1"
+              >
+                <option value="trueFalse">Verdadero/Falso</option>
+                <option value="multiple">Opción Múltiple</option>
+                <option value="match">Relacionar</option>
+                <option value="open">Abierta</option>
+                <option value="fill">Completar</option>
+              </select>
+              <input
+                type="text"
+                placeholder="Título"
+                value={q.title}
+                onChange={(e) => {
+                  const qs = [...quizData.questions];
+                  qs[idx].title = e.target.value;
+                  setQuizData({ ...quizData, questions: qs });
+                }}
+                className="w-full border p-1"
+              />
+              <input
+                type="text"
+                placeholder="Subtítulo"
+                value={q.subtitle}
+                onChange={(e) => {
+                  const qs = [...quizData.questions];
+                  qs[idx].subtitle = e.target.value;
+                  setQuizData({ ...quizData, questions: qs });
+                }}
+                className="w-full border p-1"
+              />
+              {/* Options for types that require them */}
+              {(q.type === 'trueFalse' || q.type === 'multiple') && (
+                <textarea
+                  placeholder="Opciones (una por línea, prefijar con * la correcta)"
+                  value={(q.options || []).map((o) => `${o.correct ? '*' : ''}${o.text}`).join('\n')}
+                  onChange={(e) => {
+                    const lines = e.target.value.split(/\n+/).filter(Boolean);
+                    const opts = lines.map((l,i)=>({id:String.fromCharCode(65+i), text:l.replace(/^\*/,''), correct:l.startsWith('*')}));
+                    const qs = [...quizData.questions];
+                    qs[idx].options = opts;
+                    setQuizData({ ...quizData, questions: qs });
+                  }}
+                  className="w-full border p-1"
+                />
+              )}
+            </div>
+          ))}
+          <button onClick={addQuestion} className="bg-gray-200 px-3 py-1 rounded">Agregar Pregunta</button>
+          <div>
+            <button onClick={saveQuiz} className="bg-blue-500 text-white px-4 py-2 rounded mr-2">Guardar</button>
+            <button onClick={() => setEditingId(null)} className="bg-gray-300 px-4 py-2 rounded">Cancelar</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminPanel;

--- a/src/components/QuizView.js
+++ b/src/components/QuizView.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { ref, onValue } from 'firebase/database';
+import { database } from '../config/firebase';
+import { useParams } from 'react-router-dom';
+
+const QuizView = () => {
+  const { id } = useParams();
+  const [quiz, setQuiz] = useState(null);
+
+  useEffect(() => {
+    if (!database) return;
+    const qRef = ref(database, `quizzes/${id}`);
+    const unsub = onValue(qRef, snap => {
+      setQuiz(snap.val());
+    });
+    return () => unsub();
+  }, [id]);
+
+  if (!quiz) return <p className="p-4">Cargando...</p>;
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">{quiz.title}</h1>
+      {quiz.questions && quiz.questions.map((q,idx)=>(
+        <div key={idx} className="border p-2 rounded">
+          <p className="font-medium">{q.title}</p>
+          <p className="text-sm text-gray-600">{q.subtitle}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default QuizView;

--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getDatabase } from 'firebase/database';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -13,10 +14,14 @@ const firebaseConfig = {
 
 // Initialize Firebase only if config is provided
 let database = null;
+let auth = null;
+let googleProvider = null;
 
 if (firebaseConfig.apiKey) {
   const app = initializeApp(firebaseConfig);
   database = getDatabase(app);
+  auth = getAuth(app);
+  googleProvider = new GoogleAuthProvider();
 }
 
-export { database };
+export { database, auth, googleProvider };

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { signInWithPopup, signOut, onAuthStateChanged } from 'firebase/auth';
+import { auth, googleProvider } from '../config/firebase';
+
+export const useAuth = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    if (!auth) return;
+    const unsub = onAuthStateChanged(auth, (u) => setUser(u));
+    return () => unsub();
+  }, []);
+
+  const signIn = async () => {
+    if (!auth) return;
+    await signInWithPopup(auth, googleProvider);
+  };
+
+  const signOutUser = async () => {
+    if (!auth) return;
+    await signOut(auth);
+  };
+
+  return { user, signIn, signOut: signOutUser };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,13 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import './dark-theme.css';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- integrate React Router to add `/admin` and `/quiz/:id` routes
- implement `AdminPanel` with Google sign‑in for managing quizzes
- expose firebase auth helpers
- add `QuizView` page to load a quiz
- document admin workflow in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841e8a31f84833097184a367fc35534