### PR TITLE
Support quiz-specific sessions in Firebase

### DIFF
--- a/src/components/ResultsView.js
+++ b/src/components/ResultsView.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { Users } from 'lucide-react';
 import { questions } from '../utils/questions';
 import { useSession } from '../hooks/useSession';
+import { QUIZ_ID } from '../utils/constants';
 
 const ResultsView = ({ sessionCode, onBack }) => {
-  const { responses } = useSession(sessionCode);
+  const { responses } = useSession(QUIZ_ID, sessionCode);
 
   // Calcular estadísticas
   const calculateStats = () => {

--- a/src/components/StudentView.js
+++ b/src/components/StudentView.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { CheckCircle, ChevronRight } from 'lucide-react';
 import { questions } from '../utils/questions';
 import { useSession } from '../hooks/useSession';
+import { QUIZ_ID } from '../utils/constants';
 
 const StudentView = ({ sessionCode: initialSessionCode }) => {
   const [studentName, setStudentName] = useState('');
@@ -17,7 +18,7 @@ const StudentView = ({ sessionCode: initialSessionCode }) => {
   const [submitted, setSubmitted] = useState(false);
   const [showNameForm, setShowNameForm] = useState(true);
 
-  const { submitResponse } = useSession(sessionInput);
+  const { submitResponse } = useSession(QUIZ_ID, sessionInput);
 
   const handleStartQuiz = () => {
     if (studentName.trim()) {

--- a/src/components/TeacherView.js
+++ b/src/components/TeacherView.js
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { Users, Eye } from 'lucide-react';
 import QRGenerator from './QRGenerator';
 import { useSession } from '../hooks/useSession';
+import { QUIZ_ID } from '../utils/constants';
 
 const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode }) => {
   const [sessionCode, setSessionCode] = useState(initialSessionCode || '');
-  const { responses, createSession, clearSession } = useSession(sessionCode);
+  const { responses, createSession, clearSession } = useSession(QUIZ_ID, sessionCode);
 
   const handleReset = async () => {
     await clearSession();

--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { ref, set, onValue, push, remove } from 'firebase/database';
 import { database } from '../config/firebase';
 
-export const useSession = (sessionCode) => {
+export const useSession = (quizId, sessionCode) => {
   const [session, setSession] = useState(null);
   const [responses, setResponses] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -13,7 +13,7 @@ export const useSession = (sessionCode) => {
       return;
     }
 
-    const sessionRef = ref(database, `sessions/${sessionCode}`);
+    const sessionRef = ref(database, `sessions/${quizId}/${sessionCode}`);
     const unsubscribe = onValue(sessionRef, (snapshot) => {
       const data = snapshot.val();
       if (data) {
@@ -30,13 +30,13 @@ export const useSession = (sessionCode) => {
     });
 
     return () => unsubscribe();
-  }, [sessionCode]);
+  }, [quizId, sessionCode]);
 
   const createSession = async () => {
     const code = Math.random().toString(36).substring(2, 8).toUpperCase();
     
     if (database) {
-      const sessionRef = ref(database, `sessions/${code}`);
+      const sessionRef = ref(database, `sessions/${quizId}/${code}`);
       await set(sessionRef, {
         code,
         createdAt: Date.now(),
@@ -51,7 +51,7 @@ export const useSession = (sessionCode) => {
   const submitResponse = async (studentName, answers) => {
     if (!database) return;
 
-    const responsesRef = ref(database, `sessions/${sessionCode}/responses`);
+    const responsesRef = ref(database, `sessions/${quizId}/${sessionCode}/responses`);
     await push(responsesRef, {
       studentName,
       answers,
@@ -61,7 +61,7 @@ export const useSession = (sessionCode) => {
 
   const clearSession = async () => {
     if (!database || !sessionCode) return;
-    const sessionRef = ref(database, `sessions/${sessionCode}`);
+    const sessionRef = ref(database, `sessions/${quizId}/${sessionCode}`);
     await remove(sessionRef);
   };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const QUIZ_ID = 'procedimientos-operativos';


### PR DESCRIPTION
## Summary
- include constant `QUIZ_ID`
- adapt `useSession` hook to use `quizId` when storing sessions
- pass `QUIZ_ID` to `useSession` in Teacher, Student and Results views

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e8a4c24083309aa9e2666878400e