### PR TITLE
Add quizId-aware QR links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,15 @@ import ResultsView from './components/ResultsView';
 function App() {
   const [mode, setMode] = useState('landing');
   const [sessionCode, setSessionCode] = useState('');
+  const [quizId, setQuizId] = useState('');
 
   useEffect(() => {
+    // Extract quiz id from path if present
+    const parts = window.location.pathname.split('/').filter(Boolean);
+    if (parts[0] === 'quiz' && parts[1]) {
+      setQuizId(parts[1]);
+    }
+
     // Check if there's a session code in the URL
     const urlParams = new URLSearchParams(window.location.search);
     const sessionFromUrl = urlParams.get('session');
@@ -30,6 +37,7 @@ function App() {
         <TeacherView
           onModeSelect={handleModeSelect}
           sessionCode={sessionCode}
+          quizId={quizId}
         />
       )}
       {mode === 'student' && <StudentView sessionCode={sessionCode} />}

--- a/src/components/QRGenerator.js
+++ b/src/components/QRGenerator.js
@@ -2,12 +2,15 @@ import React, { useEffect, useState } from 'react';
 import QRCode from 'qrcode';
 import { QrCode } from 'lucide-react';
 
-const QRGenerator = ({ sessionCode }) => {
+const QRGenerator = ({ sessionCode, quizId }) => {
   const [qrCodeUrl, setQrCodeUrl] = useState('');
 
   useEffect(() => {
     const generateQR = async () => {
-      const url = `${window.location.origin}?session=${sessionCode}`;
+      const base = quizId
+        ? `${window.location.origin}/quiz/${quizId}`
+        : `${window.location.origin}`;
+      const url = `${base}?session=${sessionCode}`;
       try {
         const qrUrl = await QRCode.toDataURL(url, {
           width: 300,
@@ -26,7 +29,7 @@ const QRGenerator = ({ sessionCode }) => {
     if (sessionCode) {
       generateQR();
     }
-  }, [sessionCode]);
+  }, [sessionCode, quizId]);
 
   return (
     <div className="bg-gray-800 rounded-2xl p-8 mx-auto max-w-sm">

--- a/src/components/TeacherView.js
+++ b/src/components/TeacherView.js
@@ -3,7 +3,7 @@ import { Users, Eye } from 'lucide-react';
 import QRGenerator from './QRGenerator';
 import { useSession } from '../hooks/useSession';
 
-const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode }) => {
+const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode, quizId }) => {
   const [sessionCode, setSessionCode] = useState(initialSessionCode || '');
   const { responses, createSession, clearSession } = useSession(sessionCode);
 
@@ -41,7 +41,7 @@ const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode }) => {
             Los estudiantes pueden unirse escaneando el código QR
           </p>
           
-          <QRGenerator sessionCode={sessionCode} />
+          <QRGenerator sessionCode={sessionCode} quizId={quizId} />
           
           <div className="mt-6 mb-6">
             <p className="text-gray-400 mb-2">O ingresando el código:</p>


### PR DESCRIPTION
## Summary
- support quizId parameter when generating QR links
- propagate quizId to TeacherView
- parse quizId from URL path in App

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841e8a58a588330baddc1c79529473c