### PR TITLE
Fix build error due to duplicate import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import './dark-theme.css';
 import App from './App';
-import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- remove repeated `BrowserRouter` import

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68420d5405e0833081732244faf46288