### PR TITLE
Add dynamic quiz loading

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,65 +1,14 @@
-
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Routes, Route } from 'react-router-dom';
-import Landing from './components/Landing';
-import TeacherView from './components/TeacherView';
-import StudentView from './components/StudentView';
-import ResultsView from './components/ResultsView';
+import Home from './components/Home';
 import AdminPanel from './components/AdminPanel';
 import QuizView from './components/QuizView';
-
-function Home() {
-  const [mode, setMode] = useState('landing');
-  const [sessionCode, setSessionCode] = useState('');
-  const [quizId, setQuizId] = useState('');
-
-  useEffect(() => {
-    // Extract quiz id from path if present
-    const parts = window.location.pathname.split('/').filter(Boolean);
-    if (parts[0] === 'quiz' && parts[1]) {
-      setQuizId(parts[1]);
-    }
-
-    // Check if there's a session code in the URL
-    const urlParams = new URLSearchParams(window.location.search);
-    const sessionFromUrl = urlParams.get('session');
-    if (sessionFromUrl) {
-      setSessionCode(sessionFromUrl);
-      setMode('student');
-    }
-  }, []);
-
-  const handleModeSelect = (newMode, code = '') => {
-    setMode(newMode);
-    if (code) setSessionCode(code);
-  };
-
-  return (
-    <>
-      {mode === 'landing' && <Landing onModeSelect={handleModeSelect} />}
-      {mode === 'teacher' && (
-        <TeacherView
-          onModeSelect={handleModeSelect}
-          sessionCode={sessionCode}
-          quizId={quizId}
-        />
-      )}
-      {mode === 'student' && <StudentView sessionCode={sessionCode} />}
-      {mode === 'results' && (
-        <ResultsView
-          sessionCode={sessionCode}
-          onBack={() => handleModeSelect('teacher', sessionCode)}
-        />
-      )}
-    </>
-  );
-}
 
 function App() {
   return (
     <Routes>
       <Route path="/admin" element={<AdminPanel />} />
-      <Route path="/quiz/:id" element={<QuizView />} />
+      <Route path="/quiz/:quizId" element={<QuizView />} />
       <Route path="*" element={<Home />} />
     </Routes>
   );

--- a/src/components/ResultsView.js
+++ b/src/components/ResultsView.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Users } from 'lucide-react';
 import { useSession } from '../hooks/useSession';
-import { QUIZ_ID } from '../utils/constants';
 
 
-const ResultsView = ({ sessionCode, onBack }) => {
-  const { responses } = useSession(QUIZ_ID, sessionCode);
+
+const ResultsView = ({ sessionCode, quizId, onBack, questions = [] }) => {
+  const { responses } = useSession(quizId, sessionCode);
 
 
   // Calcular estadísticas

--- a/src/components/StudentView.js
+++ b/src/components/StudentView.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { CheckCircle, ChevronRight } from 'lucide-react';
 import { useSession } from '../hooks/useSession';
-import { QUIZ_ID } from '../utils/constants';
 
 const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }) => {
   const [studentName, setStudentName] = useState('');
@@ -18,7 +17,7 @@ const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }
   const [showNameForm, setShowNameForm] = useState(true);
 
 
-  const { submitResponse } = useSession(QUIZ_ID, sessionInput);
+  const { submitResponse } = useSession(quizId, sessionInput);
 
 
   const handleStartQuiz = () => {

--- a/src/components/TeacherView.js
+++ b/src/components/TeacherView.js
@@ -2,13 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { Users, Eye } from 'lucide-react';
 import QRGenerator from './QRGenerator';
 import { useSession } from '../hooks/useSession';
-import { QUIZ_ID } from '../utils/constants';
 
 
 const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode, quizId }) => {
 
   const [sessionCode, setSessionCode] = useState(initialSessionCode || '');
-  const { responses, createSession, clearSession } = useSession(QUIZ_ID, sessionCode);
+  const { responses, createSession, clearSession } = useSession(quizId, sessionCode);
 
 
   const handleReset = async () => {

--- a/src/hooks/useQuizData.js
+++ b/src/hooks/useQuizData.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { ref, onValue } from 'firebase/database';
+import { database } from '../config/firebase';
+
+export const useQuizData = (quizId) => {
+  const [quiz, setQuiz] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!quizId || !database) {
+      setLoading(false);
+      return;
+    }
+    const qRef = ref(database, `quizzes/${quizId}`);
+    const unsub = onValue(qRef, snap => {
+      setQuiz(snap.val());
+      setLoading(false);
+    });
+    return () => unsub();
+  }, [quizId]);
+
+  return { quiz, loading };
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/quiz/(.*)", "destination": "/" },
+    { "source": "/admin/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- load quiz data with new `useQuizData` hook
- make quiz route interactive via new `QuizView`
- pass `quizId` throughout student, teacher and results views
- simplify router setup
- add Vercel SPA rewrites

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68420fdbb2d08330aed575b0be540a19