### PR TITLE
Fix Firebase key handling and responsive UI

### DIFF
--- a/src/components/AdminPanel.js
+++ b/src/components/AdminPanel.js
@@ -49,14 +49,24 @@ const AdminPanel = () => {
 
   const handleSave = useCallback(async () => {
     if (!database || !editingId) return;
-    if (!quiz.title || quiz.questions.length === 0) return;
+    if (!quiz.title || quiz.questions.length === 0) {
+      alert('El quiz debe tener título y al menos una pregunta');
+      return;
+    }
     setStatus('saving');
-    await set(ref(database, `quizzes/${editingId}`), {
-      ...quiz,
-      updatedAt: Date.now(),
-      id: editingId
-    });
-    setStatus('saved');
+    try {
+      await set(ref(database, `quizzes/${editingId}`), {
+        ...quiz,
+        updatedAt: Date.now(),
+        id: editingId
+      });
+      setStatus('saved');
+      setTimeout(() => setStatus('idle'), 2000);
+    } catch (error) {
+      console.error('Error guardando:', error);
+      alert('Error al guardar el quiz');
+      setStatus('idle');
+    }
   }, [editingId, quiz]);
 
   const updateQuestion = (idx, field, value) => {

--- a/src/components/QuizView.js
+++ b/src/components/QuizView.js
@@ -37,7 +37,10 @@ const QuizView = () => {
           onModeSelect={handleModeSelect}
           quizTitle={quiz.title}
           quizDescription={quiz.description}
-          quizStats={{ questions: quiz.questions?.length || 0 }}
+          quizStats={{
+            questions: quiz.questions?.length || 0,
+            id: quizId
+          }}
         />
       )}
       {mode === 'teacher' && (

--- a/src/components/ResultsView.js
+++ b/src/components/ResultsView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Users } from 'lucide-react';
+import { Users, TrendingUp, CheckCircle, XCircle } from 'lucide-react';
 import { useSession } from '../hooks/useSession';
 
 
@@ -36,14 +36,27 @@ const ResultsView = ({ sessionCode, quizId, onBack, questions = [] }) => {
       // Q2
       if (answers.q2) stats.q2[answers.q2]++;
 
-      // Q3
-      if (answers.q3) {
-        // Mapear claves seguras a los textos originales para comparar
-        const a = answers.q3['A'] || answers.q3['A. Procedimiento Operativo'];
-        const b = answers.q3['B'] || answers.q3['B. Práctica de Trabajo Seguro'];
-        const correctQ3 = a === '2' && b === '1';
-        if (correctQ3) stats.q3.correct++;
-        else stats.q3.incorrect++;
+      // Q3 - Relacionar columnas con manejo de claves sanitizadas
+      if (answers.q3 && questions[2]) {
+        let correctCount = 0;
+        const expectedPairs = questions[2].pairs || [];
+
+        expectedPairs.forEach(pair => {
+          // Intentar con clave sanitizada primero, luego original
+          const sanitizedKey = pair.concept.replace(/[.#$\[\]/]/g, '_');
+          const userAnswer = answers.q3[sanitizedKey] || answers.q3[pair.concept];
+
+          if (userAnswer === pair.correctAnswer) {
+            correctCount++;
+          }
+        });
+
+        const isFullyCorrect = correctCount === expectedPairs.length;
+        if (isFullyCorrect) {
+          stats.q3.correct++;
+        } else {
+          stats.q3.incorrect++;
+        }
       }
       // Q4
       if (answers.q4) stats.q4.push(answers.q4);
@@ -86,7 +99,7 @@ const ResultsView = ({ sessionCode, quizId, onBack, questions = [] }) => {
           </button>
         </div>
 
-        <div className="grid md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Pregunta 1 */}
           <div className="bg-gray-900 rounded-3xl p-6">
             <h3 className="text-xl font-medium mb-4">Pregunta 1: Verdadero o Falso</h3>
@@ -183,9 +196,9 @@ const ResultsView = ({ sessionCode, quizId, onBack, questions = [] }) => {
           </div>
 
           {/* Pregunta 5 */}
-          <div className="bg-gray-900 rounded-3xl p-6 md:col-span-2">
+          <div className="bg-gray-900 rounded-3xl p-6 lg:col-span-2">
             <h3 className="text-xl font-medium mb-4">Pregunta 5: Palabras Más Usadas</h3>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
                 <p className="text-sm text-gray-400 mb-2">Primer espacio:</p>
                 {Object.keys(stats.q5.blank1).length > 0 ? (

--- a/src/components/StudentView.js
+++ b/src/components/StudentView.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { CheckCircle, ChevronRight } from 'lucide-react';
+import { CheckCircle, ChevronRight, AlertCircle } from 'lucide-react';
 import { useSession } from '../hooks/useSession';
 
 const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }) => {
@@ -15,12 +15,23 @@ const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }
   });
   const [submitted, setSubmitted] = useState(false);
   const [showNameForm, setShowNameForm] = useState(true);
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
 
   const { submitResponse } = useSession(quizId, sessionInput);
 
 
   const handleStartQuiz = () => {
+    setError('');
+    if (!studentName.trim()) {
+      setError('Por favor ingresa tu nombre');
+      return;
+    }
+    if (!sessionInput.trim()) {
+      setError('Por favor ingresa el código de sesión');
+      return;
+    }
     if (studentName.trim()) {
       setShowNameForm(false);
     }
@@ -32,20 +43,34 @@ const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }
     'B. Práctica de Trabajo Seguro': 'B'
   };
 
-  // --- Al guardar respuestas, convertir claves peligrosas a seguras ---
   const handleSubmit = async () => {
-    let safeAnswers = { ...answers };
-    if (safeAnswers.q3) {
-      const safeQ3 = {};
-      Object.entries(safeAnswers.q3).forEach(([k, v]) => {
-        const safeKey = matchKeyMap[k] || k;
-        safeQ3[safeKey] = v;
-      });
-      safeAnswers.q3 = safeQ3;
+    if (!sessionInput) {
+      alert('Por favor ingresa un código de sesión');
+      return;
     }
-    if (!sessionInput) return;
-    await submitResponse(studentName, safeAnswers);
-    setSubmitted(true);
+
+    try {
+      // Sanitizar respuestas para Firebase - CRÍTICO
+      const sanitizeForFirebase = (obj) => {
+        if (typeof obj !== 'object' || obj === null) return obj;
+
+        const sanitized = {};
+        Object.entries(obj).forEach(([key, value]) => {
+          // Firebase no permite . # $ [ ] / en las claves
+          const safeKey = key.replace(/[.#$\[\]/]/g, '_');
+          sanitized[safeKey] =
+            typeof value === 'object' ? sanitizeForFirebase(value) : value;
+        });
+        return sanitized;
+      };
+
+      const safeAnswers = sanitizeForFirebase(answers);
+      await submitResponse(studentName, safeAnswers);
+      setSubmitted(true);
+    } catch (error) {
+      console.error('Error al enviar respuestas:', error);
+      alert('Error al enviar las respuestas. Intenta nuevamente.');
+    }
   };
 
   if (showNameForm) {
@@ -56,7 +81,14 @@ const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }
           <h1 className="text-4xl font-semibold text-center mb-8 bg-gradient-to-r from-blue-400 to-purple-600 bg-clip-text text-transparent">
             Unirse al Quiz
           </h1>
-          
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-500/10 border border-red-500/50 rounded-xl flex items-center gap-2">
+              <AlertCircle className="w-5 h-5 text-red-500" />
+              <span className="text-sm text-red-500">{error}</span>
+            </div>
+          )}
+
           <div className="bg-gray-900 rounded-3xl p-8">
             <label className="block text-sm text-gray-400 mb-2">Tu nombre</label>
             <input
@@ -201,7 +233,11 @@ const StudentView = ({ quizId, sessionCode: initialSessionCode, questions = [] }
                           onClick={() =>
                             setAnswers({
                               ...answers,
-                              q3: { ...answers.q3, [pair.concept]: def.id }
+                              q3: {
+                                ...answers.q3,
+                                [pair.concept.replace(/[.#$\[\]/]/g, '_')]:
+                                  def.id
+                              }
                             })
                           }
                           className={`px-6 py-2 rounded-full transition-all ${

--- a/src/components/TeacherView.js
+++ b/src/components/TeacherView.js
@@ -56,7 +56,9 @@ const TeacherView = ({ onModeSelect, sessionCode: initialSessionCode, quizId, qu
           </p>
           
 
-          <QRGenerator sessionCode={sessionCode} quizId={quizId} />
+          <div className="max-w-sm mx-auto mb-6">
+            <QRGenerator sessionCode={sessionCode} quizId={quizId} />
+          </div>
 
           
           <div className="mt-6 mb-6">

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,19 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+/* Custom scrollbar */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: #1f2937;
+  border-radius: 3px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #4b5563;
+  border-radius: 3px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #6b7280;
+}


### PR DESCRIPTION
## Summary
- sanitize Firebase keys when submitting and reading answers
- handle sanitized keys in results and matching logic
- enhance responsive layouts and add custom scrollbar
- improve quiz admin validation and teacher QR container
- pass quiz id to landing view

## Testing
- `npm start`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68421deefefc83308e07b1493f8b9f4c